### PR TITLE
Add wayland library path and link wayland libraries

### DIFF
--- a/client/client.pro
+++ b/client/client.pro
@@ -32,6 +32,9 @@ isEmpty(INCLUDE_INSTALL_DIR) {
     includes.path = $$INCLUDE_INSTALL_DIR
 }
 
+INCLUDEPATH += /usr/include/wayland
+LIBS += -L$$LIB_INSTALL_DIR -lwayland-client
+
 includes.files += \
     $$PWD/dshellsurface.h
 

--- a/server/server.pro
+++ b/server/server.pro
@@ -33,6 +33,9 @@ isEmpty(INCLUDE_INSTALL_DIR) {
     includes.path = $$INCLUDE_INSTALL_DIR
 }
 
+INCLUDEPATH += /usr/include/wayland
+LIBS += -L$$LIB_INSTALL_DIR -lwayland-server
+
 includes.files += \
     $$PWD/dshellsurface.h
 


### PR DESCRIPTION
- Make sure wayland library profiles can be found by compiler
- Make sure the compiler link check won't report an error.